### PR TITLE
Simplify Utils.ScreenSize

### DIFF
--- a/src/main/java/no/hyper/imagecrop/Utils.java
+++ b/src/main/java/no/hyper/imagecrop/Utils.java
@@ -18,10 +18,8 @@ public class Utils {
             Display display = wm.getDefaultDisplay();
             Point size = new Point();
             display.getSize(size);
-            int width = size.x;
-            int height = size.y;
 
-            return width;
+            return size.x;
         }
 
         public static int getHeight(Context ctx) {
@@ -29,10 +27,8 @@ public class Utils {
             Display display = wm.getDefaultDisplay();
             Point size = new Point();
             display.getSize(size);
-            int width = size.x;
-            int height = size.y;
 
-            return height;
+            return size.y;
         }
     }
 


### PR DESCRIPTION
Remove unused and redundant variables in `Utils.ScreenSize.getWidth` and `Utils.ScreenSize.getHeight`.
