### PR TITLE
Fix indentation in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ Declare in XML
     android:layout_height="match_parent"
     android:background="#000000">
 
-  <no.hyper.imagecrop.ImageCropper
-          android:id="@+id/image_cropper"
-          android:layout_width="match_parent"
-          android:layout_height="match_parent"
-          custom:crop_size="200"/>
+    <no.hyper.imagecrop.ImageCropper
+        android:id="@+id/image_cropper"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        custom:crop_size="200"/>
   
-  <no.hyper.imagecrop.Overlay
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      custom:crop_size="200"/>
+    <no.hyper.imagecrop.Overlay
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        custom:crop_size="200"/>
       
 </FrameLayout>
 ```


### PR DESCRIPTION
Consistently use four spaces for indentation in the XML example.
